### PR TITLE
Use spaces for key binding menu

### DIFF
--- a/OpenTAP.TUI/KeyMapper.cs
+++ b/OpenTAP.TUI/KeyMapper.cs
@@ -7,9 +7,12 @@ namespace OpenTap.Tui
     public enum KeyTypes
     {
         Save,
+        [Display("Save As")]
         SaveAs,
         Open,
+        [Display("Add New Step")]
         AddNewStep,
+        [Display("Insert New Step")]
         InsertNewStep,
         Copy,
         Paste


### PR DESCRIPTION
This adds some spaces to the name of keybindings with multiple words