### PR TITLE
i31 Support collapse/expand step serialization

### DIFF
--- a/OpenTAP.TUI/OpenTap.Tui.csproj
+++ b/OpenTAP.TUI/OpenTap.Tui.csproj
@@ -5,7 +5,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <OutputType>Library</OutputType>
-    <OpenTapVersion>9.12.0</OpenTapVersion>
+    <OpenTapVersion>9.18.3</OpenTapVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OpenTAP.TUI/Views/TestPlanView.cs
+++ b/OpenTAP.TUI/Views/TestPlanView.cs
@@ -30,7 +30,7 @@ namespace OpenTap.Tui.Views
             CanFocus = true;
             Title = "Test Plan";
             
-            treeView = new TreeView<ITestStep>(getTitle, getChildren, getParent)
+            treeView = new TreeView<ITestStep>(getTitle, getChildren, getParent, createNode)
             {
                 Height = Dim.Fill(),
                 Width = Dim.Fill()
@@ -43,6 +43,8 @@ namespace OpenTap.Tui.Views
             };
             treeView.EnableFilter = true;
             treeView.FilterChanged += (filter) => { Title = string.IsNullOrEmpty(filter) ? "Test Plan" : $"Test Plan - {filter}"; };
+            treeView.NodeCollapsed += (step) => ChildItemVisibility.SetVisibility(step, ChildItemVisibility.Visibility.Collapsed);
+            treeView.NodeExpanded += (step) => ChildItemVisibility.SetVisibility(step, ChildItemVisibility.Visibility.Visible);
             Add(treeView);
             
             actions = new List<MenuItem>();
@@ -83,6 +85,13 @@ namespace OpenTap.Tui.Views
         ITestStep getParent(ITestStep step)
         {
             return step.Parent as ITestStep;
+        }
+        TreeViewNode<ITestStep> createNode(ITestStep step)
+        {
+            return new TreeViewNode<ITestStep>(step, treeView)
+            {
+                IsExpanded = ChildItemVisibility.GetVisibility(step) == ChildItemVisibility.Visibility.Visible
+            };
         }
 
         public override bool OnEnter(View view)

--- a/OpenTAP.TUI/Views/TestPlanView.cs
+++ b/OpenTAP.TUI/Views/TestPlanView.cs
@@ -43,8 +43,8 @@ namespace OpenTap.Tui.Views
             };
             treeView.EnableFilter = true;
             treeView.FilterChanged += (filter) => { Title = string.IsNullOrEmpty(filter) ? "Test Plan" : $"Test Plan - {filter}"; };
-            treeView.NodeCollapsed += (step) => ChildItemVisibility.SetVisibility(step, ChildItemVisibility.Visibility.Collapsed);
-            treeView.NodeExpanded += (step) => ChildItemVisibility.SetVisibility(step, ChildItemVisibility.Visibility.Visible);
+            treeView.NodeCollapsed += (step) => ChildItemVisibility.SetVisibility(step.Item, ChildItemVisibility.Visibility.Collapsed);
+            treeView.NodeExpanded += (step) => ChildItemVisibility.SetVisibility(step.Item, ChildItemVisibility.Visibility.Visible);
             Add(treeView);
             
             actions = new List<MenuItem>();

--- a/OpenTAP.TUI/Views/TreeView.cs
+++ b/OpenTAP.TUI/Views/TreeView.cs
@@ -19,8 +19,8 @@ namespace OpenTap.Tui
         public bool EnableFilter { get; set; }
         public string Filter { get; set; } = "";
         public Action<string> FilterChanged { get; set; }
-        public event Action<T> NodeCollapsed;
-        public event Action<T> NodeExpanded;
+        internal event Action<TreeViewNode<T>> NodeCollapsed;
+        internal event Action<TreeViewNode<T>> NodeExpanded;
         
         public T SelectedObject
         {
@@ -237,12 +237,12 @@ namespace OpenTap.Tui
                     if (kb.Key == Key.CursorLeft)
                     {
                         selectedNode.IsExpanded = false;
-                        NodeCollapsed?.Invoke(selectedNode.Item);
+                        NodeCollapsed?.Invoke(selectedNode);
                     }
                     if (kb.Key == Key.CursorRight)
                     {
                         selectedNode.IsExpanded = true;
-                        NodeExpanded?.Invoke(selectedNode.Item);
+                        NodeExpanded?.Invoke(selectedNode);
                     }
                 }
 


### PR DESCRIPTION
Support collapse and expand steps from OpenTap,
updated OpenTap reference to 9.18.3 as this is required for collapse/expand serialization support.

Closes #31 