### PR TITLE
i14 remember settings state

### DIFF
--- a/OpenTAP.TUI/OpenTap.Tui.csproj
+++ b/OpenTAP.TUI/OpenTap.Tui.csproj
@@ -5,7 +5,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <OutputType>Library</OutputType>
-    <OpenTapVersion>9.12.0</OpenTapVersion>
+    <OpenTapVersion>9.18.3</OpenTapVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OpenTAP.TUI/Views/PropertiesView.cs
+++ b/OpenTAP.TUI/Views/PropertiesView.cs
@@ -77,13 +77,15 @@ namespace OpenTap.Tui.Views
         
         public PropertiesView(bool EnableFilter = false)
         {
-            treeView = new TreeView<AnnotationCollection>(getTitle, getGroup);
+            treeView = new TreeView<AnnotationCollection>(getTitle, getGroup, CreateNode, CreateGroupNode);
             treeView.CanFocus = true;
             treeView.Height = Dim.Percent(75);
             treeView.SelectedItemChanged += ListViewOnSelectedChanged;
             treeView.OpenSelectedItem += OpenSelectedItem;
             treeView.EnableFilter = EnableFilter;
             treeView.FilterChanged += (f) => TreeViewFilterChanged?.Invoke(f);
+            treeView.NodeCollapsed += NodeCollapsed;
+            treeView.NodeExpanded += NodeExpanded;
             Add(treeView);
 
             // Description
@@ -214,6 +216,49 @@ namespace OpenTap.Tui.Views
             return annotationCollection?.Get<DisplayAttribute>().Group.ToList();
         }
 
+
+        private readonly Dictionary<object, Dictionary<string, bool>> _allExpandedStepProperties = new Dictionary<object, Dictionary<string, bool>>();
+        private Dictionary<string, bool> _expandedStepProperties;
+        private TreeViewNode<AnnotationCollection> CreateNode(AnnotationCollection annotations)
+        {
+            string name = annotations.Get<DisplayAttribute>().Name;
+            if (!_expandedStepProperties.TryGetValue(name, out bool expanded))
+            {
+                expanded = false;
+                _expandedStepProperties[name] = expanded;
+            }
+            var node = new TreeViewNode<AnnotationCollection>(annotations, treeView)
+            {
+                IsExpanded = expanded,
+            };
+            return node;
+        }
+
+        private TreeViewNode<AnnotationCollection> CreateGroupNode(TreeViewNode<AnnotationCollection> node, string group)
+        {
+            if (!_expandedStepProperties.TryGetValue(group, out bool expanded))
+            {
+                expanded = false;
+                _expandedStepProperties[group] = expanded;
+            }
+            var groupNode = new TreeViewNode<AnnotationCollection>(default(AnnotationCollection), treeView)
+            {
+                Title = group,
+                IsExpanded = expanded,
+            };
+            return groupNode;
+        }
+
+        private void NodeExpanded(TreeViewNode<AnnotationCollection> node)
+        {
+            _expandedStepProperties[node.Item?.Get<DisplayAttribute>().Name ?? node.Title] = true;
+        }
+
+        private void NodeCollapsed(TreeViewNode<AnnotationCollection> node)
+        {
+            _expandedStepProperties[node.Item.Get<DisplayAttribute>().Name] = false;
+        }
+
         List<Button> getSubmitButtons()
         {
             // Get submit buttons
@@ -309,6 +354,11 @@ namespace OpenTap.Tui.Views
         public void LoadProperties(object obj)
         {
             this.obj = obj ?? new object();
+            if (!_allExpandedStepProperties.TryGetValue(obj, out _expandedStepProperties))
+            {
+                _expandedStepProperties = new Dictionary<string, bool>();
+                _allExpandedStepProperties.Add(obj, _expandedStepProperties);
+            }
             annotations = AnnotationCollection.Annotate(obj);
             var members = getMembers();
             if (members == null)

--- a/OpenTAP.TUI/Views/TestPlanView.cs
+++ b/OpenTAP.TUI/Views/TestPlanView.cs
@@ -30,7 +30,7 @@ namespace OpenTap.Tui.Views
             CanFocus = true;
             Title = "Test Plan";
             
-            treeView = new TreeView<ITestStep>(getTitle, getChildren, getParent)
+            treeView = new TreeView<ITestStep>(getTitle, getChildren, getParent, createNode)
             {
                 Height = Dim.Fill(),
                 Width = Dim.Fill()
@@ -43,6 +43,8 @@ namespace OpenTap.Tui.Views
             };
             treeView.EnableFilter = true;
             treeView.FilterChanged += (filter) => { Title = string.IsNullOrEmpty(filter) ? "Test Plan" : $"Test Plan - {filter}"; };
+            treeView.NodeCollapsed += (step) => ChildItemVisibility.SetVisibility(step, ChildItemVisibility.Visibility.Collapsed);
+            treeView.NodeExpanded += (step) => ChildItemVisibility.SetVisibility(step, ChildItemVisibility.Visibility.Visible);
             Add(treeView);
             
             actions = new List<MenuItem>();
@@ -83,6 +85,13 @@ namespace OpenTap.Tui.Views
         ITestStep getParent(ITestStep step)
         {
             return step.Parent as ITestStep;
+        }
+        TreeViewNode<ITestStep> createNode(ITestStep step)
+        {
+            return new TreeViewNode<ITestStep>(step, treeView)
+            {
+                IsExpanded = ChildItemVisibility.GetVisibility(step) == ChildItemVisibility.Visibility.Visible
+            };
         }
 
         public override bool OnEnter(View view)

--- a/OpenTAP.TUI/Views/TestPlanView.cs
+++ b/OpenTAP.TUI/Views/TestPlanView.cs
@@ -43,8 +43,8 @@ namespace OpenTap.Tui.Views
             };
             treeView.EnableFilter = true;
             treeView.FilterChanged += (filter) => { Title = string.IsNullOrEmpty(filter) ? "Test Plan" : $"Test Plan - {filter}"; };
-            treeView.NodeCollapsed += (step) => ChildItemVisibility.SetVisibility(step, ChildItemVisibility.Visibility.Collapsed);
-            treeView.NodeExpanded += (step) => ChildItemVisibility.SetVisibility(step, ChildItemVisibility.Visibility.Visible);
+            treeView.NodeCollapsed += (step) => ChildItemVisibility.SetVisibility(step.Item, ChildItemVisibility.Visibility.Collapsed);
+            treeView.NodeExpanded += (step) => ChildItemVisibility.SetVisibility(step.Item, ChildItemVisibility.Visibility.Visible);
             Add(treeView);
             
             actions = new List<MenuItem>();

--- a/OpenTAP.TUI/Views/TreeView.cs
+++ b/OpenTAP.TUI/Views/TreeView.cs
@@ -19,8 +19,8 @@ namespace OpenTap.Tui
         public bool EnableFilter { get; set; }
         public string Filter { get; set; } = "";
         public Action<string> FilterChanged { get; set; }
-        public event Action<T> NodeCollapsed;
-        public event Action<T> NodeExpanded;
+        internal event Action<TreeViewNode<T>> NodeCollapsed;
+        internal event Action<TreeViewNode<T>> NodeExpanded;
         
         public T SelectedObject
         {
@@ -237,12 +237,12 @@ namespace OpenTap.Tui
                     if (kb.Key == Key.CursorLeft)
                     {
                         selectedNode.IsExpanded = false;
-                        NodeCollapsed?.Invoke(selectedNode.Item);
+                        NodeCollapsed?.Invoke(selectedNode);
                     }
                     if (kb.Key == Key.CursorRight)
                     {
                         selectedNode.IsExpanded = true;
-                        NodeExpanded?.Invoke(selectedNode.Item);
+                        NodeExpanded?.Invoke(selectedNode);
                     }
                 }
 

--- a/OpenTAP.TUI/Views/TreeView.cs
+++ b/OpenTAP.TUI/Views/TreeView.cs
@@ -12,6 +12,7 @@ namespace OpenTap.Tui
         private Func<T, List<T>> getChildren;
         private Func<T, T> getParent;
         private Func<T, TreeViewNode<T>> createNode;
+        private Func<TreeViewNode<T>, string, TreeViewNode<T>> createGroupNode;
         private IList<T> items;
         private Dictionary<T, TreeViewNode<T>> nodes;
         private Dictionary<string, TreeViewNode<T>> groups = new Dictionary<string, TreeViewNode<T>>();
@@ -28,12 +29,14 @@ namespace OpenTap.Tui
             set => SelectedItem = renderedItems.IndexOf(nodes[value]);
         }
 
-        public TreeView(Func<T, string> getTitle, Func<T, List<string>> getGroups)
+        public TreeView(Func<T, string> getTitle, Func<T, List<string>> getGroups, Func<T, TreeViewNode<T>> createNode = null, Func<TreeViewNode<T>, string, TreeViewNode<T>> createGroupNode = null)
         {
             this.getTitle = getTitle;
             this.getGroups = getGroups;
+            this.createNode = createNode;
+            this.createGroupNode = createGroupNode;
         }
-        internal TreeView(Func<T, string> getTitle, Func<T, List<T>> getChildren, Func<T, T> getParent, Func<T, TreeViewNode<T>> createNode)
+        public TreeView(Func<T, string> getTitle, Func<T, List<T>> getChildren, Func<T, T> getParent, Func<T, TreeViewNode<T>> createNode)
         {
             this.getTitle = getTitle;
             this.getChildren = getChildren;
@@ -73,11 +76,11 @@ namespace OpenTap.Tui
                 if (groups.TryGetValue(group, out groupNode) == false)
                 {
                     // add the group
-                    groupNode = new TreeViewNode<T>(default(T), this)
+                    groupNode = createGroupNode?.Invoke(node, group) ?? new TreeViewNode<T>(default(T), this)
                     {
                         Title = group,
-                        IsGroup = true
                     };
+                    groupNode.IsGroup = true;
                     groups[group] = groupNode;
                 }
                     
@@ -310,7 +313,7 @@ namespace OpenTap.Tui
         }
     }
 
-    class TreeViewNode<T>
+    public class TreeViewNode<T>
     {
         public T Item { get; set; }
         public bool IsExpanded { get; set; }


### PR DESCRIPTION
Remember the collapsed/expanded state of all groups individually for steps so they can be restored upon selecting the same step again.

Based on #31 

Closes #22 and #14