### PR TITLE
10 Running TestPlan Bug: Fix

### DIFF
--- a/OpenTAP.TUI/TuiAction.cs
+++ b/OpenTAP.TUI/TuiAction.cs
@@ -14,6 +14,18 @@ namespace OpenTap.Tui
         public static TapThread MainThread;
         public static CancellationToken CancellationToken;
         public static ICliAction CurrentAction { get; private set; }
+
+        #if DEBUG
+        const bool isDebug = true;
+        #else
+        const bool isDebug = false;
+        #endif
+        
+        public static void AssertTuiThread()
+        {
+            if (isDebug && TapThread.Current != MainThread)
+                throw new InvalidOperationException("GUI invoked from outside the GUI thread.");
+        }
         
         public int Execute(CancellationToken cancellationToken)
         {

--- a/OpenTAP.TUI/Views/TestPlanView.cs
+++ b/OpenTAP.TUI/Views/TestPlanView.cs
@@ -93,6 +93,7 @@ namespace OpenTap.Tui.Views
 
         public void Update(bool noCache = false)
         {
+            TuiAction.AssertTuiThread();
             treeView.RenderTreeView(noCache);
             MainWindow.helperButtons.SetActions(actions, this);
         }
@@ -233,9 +234,12 @@ namespace OpenTap.Tui.Views
             {
                 // Run testplan and show progress bar
                 testPlanRun = Plan.Execute();
-                PlanIsRunning = false;
-                runAction.Title = "Run Test Plan";
-                Update();
+                Application.MainLoop.Invoke(() =>
+                    {
+                        PlanIsRunning = false;
+                        runAction.Title = "Run Test Plan";
+                        Update();
+                    });
             });
             
             Task.Run(() =>


### PR DESCRIPTION
- fixed the issue by calling update from the UI thread.
- Catch errors if the TestPlanView is updated from outside the GUI thread.

Closes #10