### PR TITLE
Exception from tostring

### DIFF
--- a/OpenTAP.TUI/PropEditProviders/PropEditProvider.cs
+++ b/OpenTAP.TUI/PropEditProviders/PropEditProvider.cs
@@ -16,11 +16,18 @@ namespace OpenTap.Tui.PropEditProviders
 
             foreach (var item in editProviders)
             {
-                View view = item.Edit(annotation);
-                if (view != null)
+                try
                 {
-                    provider = item;
-                    return view;
+                    View view = item.Edit(annotation);
+                    if (view != null)
+                    {
+                        provider = item;
+                        return view;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    TUI.Log.Error(ex);
                 }
             }
 


### PR DESCRIPTION
Closes #73 

Catches any exceptions in PropEditProviders and logs them.
I would request that @rmadsen-ks tries to reproduce this issue on this branch as I am not quite sure how to reproduce it myself.