### PR TITLE
103 - Override the tostring behavoiour of keymaps in the datagrid propertyeditor

### DIFF
--- a/OpenTAP.TUI/KeyMapper.cs
+++ b/OpenTAP.TUI/KeyMapper.cs
@@ -185,6 +185,9 @@ namespace OpenTap.Tui
                     case Key.DeleteChar:
                         s.Add("Del");
                         break;
+                    case Key.Space:
+                        s.Add("Space");
+                        break;
                     default:
                         s.Add(key.ToString());
                         break;
@@ -232,7 +235,7 @@ namespace OpenTap.Tui
 
         public override string ToString()
         {
-            return KeyEvent.ToString();
+            return KeyMapHelper.KeyToString(KeyEvent.Key);
         }
     }
 }

--- a/OpenTAP.TUI/PropEditProviders/DataGridEditProvider.cs
+++ b/OpenTAP.TUI/PropEditProviders/DataGridEditProvider.cs
@@ -278,7 +278,16 @@ namespace OpenTap.Tui.PropEditProviders
                     if (members == null) cell = item;
                     else cell = members.FirstOrDefault(x2 => calcMemberName(x2.Get<IMemberAnnotation>().Member) == Columns[i]);
 
-                    var cellValue = cell?.Get<IStringReadOnlyValueAnnotation>()?.Value ?? cell?.Get<IObjectValueAnnotation>().Value?.ToString();
+                    string cellValue;
+                    // Allows us to override what is displayed for keys, ex. turns the space key from " " into "Space"
+                    if (cell?.Get<IObjectValueAnnotation>().Value is KeyEvent key)
+                    {
+                        cellValue = KeyMapHelper.KeyToString(key.Key);
+                    }
+                    else
+                    {
+                        cellValue = cell?.Get<IStringReadOnlyValueAnnotation>()?.Value ?? cell?.Get<IObjectValueAnnotation>().Value?.ToString();
+                    }
 
                     if (string.IsNullOrEmpty(cellValue))
                         row[i] = DBNull.Value;


### PR DESCRIPTION
closes #103 