### PR TITLE
92 StepSettings now respect the locked property on test plans

### DIFF
--- a/OpenTAP.TUI/OpenTAP.TUI.cs
+++ b/OpenTAP.TUI/OpenTAP.TUI.cs
@@ -167,6 +167,7 @@ namespace OpenTap.Tui
                 Height = Dim.Percent(gridHeight)
             };
             StepSettingsView = new PropertiesView(true);
+            StepSettingsView.IsReadOnly = () => TestPlanView.Plan.Locked;
 
             var filemenu = new MenuBarItem("File", new MenuItem[]
             {

--- a/OpenTAP.TUI/Views/PropertiesView.cs
+++ b/OpenTAP.TUI/Views/PropertiesView.cs
@@ -20,7 +20,7 @@ namespace OpenTap.Tui.Views
         private View submitView { get; set; }
         internal bool DisableHelperButtons { get; set; }
 
-        public bool IsReadOnly { get; set; }
+        public Func<bool> IsReadOnly { get; set; } = () => false;
 
         public Action<string> TreeViewFilterChanged { get; set; }
 
@@ -137,7 +137,7 @@ namespace OpenTap.Tui.Views
                 return;
 
             // Find edit provider
-            var propEditor = PropEditProvider.GetProvider(member, IsReadOnly, out var provider);
+            var propEditor = PropEditProvider.GetProvider(member, IsReadOnly.Invoke(), out var provider);
             if (propEditor == null)
                 TUI.Log.Warning($"Cannot edit properties of type: {member.Get<IMemberAnnotation>().ReflectionInfo.Name}");
             else


### PR DESCRIPTION
Step settings are not readonly if the testplan is locked.
closes #92 