### PR TITLE
112 Expand step if moving other steps as children.

### DIFF
--- a/OpenTAP.TUI/Views/TestPlanView.cs
+++ b/OpenTAP.TUI/Views/TestPlanView.cs
@@ -157,6 +157,11 @@ namespace OpenTap.Tui.Views
                 insertParent.ChildTestSteps.Insert(insertIndex, step);
             }
 
+            if (inject)
+            {
+                treeView.ExpandObject(selectedObject);
+            }
+
             MainWindow.ContainsUnsavedChanges = true;
             moveSteps.Clear();
             ChildItemVisibility.SetVisibility(insertParent, ChildItemVisibility.Visibility.Visible);


### PR DESCRIPTION
Previously steps wouldnt expand when inserting other steps as children to that step.

closes #112 