### PR TITLE
Fix set buffer height

### DIFF
--- a/OpenTAP.TUI/OpenTAP.TUI.cs
+++ b/OpenTAP.TUI/OpenTAP.TUI.cs
@@ -160,9 +160,35 @@ namespace OpenTap.Tui
         public PropertiesView StepSettingsView { get; set; }
         public FrameView LogFrame { get; set; }
 
+        private bool TryGetBufferHeight(out int bh)
+        {
+            try
+            {
+                bh = Console.BufferHeight;
+                return true;
+            }
+            catch
+            {
+                bh = 0;
+                return false;
+            }
+        }
+
+        private void SetBufferHeight(int h)
+        {
+            try
+            {
+                Console.BufferHeight = h;
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+
         public override int TuiExecute(CancellationToken cancellationToken)
         {
-            int bufferHeight = Console.BufferHeight;
+            bool canGetHeight = TryGetBufferHeight(out var bufferHeight);
 
             var gridWidth = TuiSettings.Current.TestPlanGridWidth;
             var gridHeight = TuiSettings.Current.TestPlanGridHeight;
@@ -408,7 +434,8 @@ namespace OpenTap.Tui
 
             Application.Shutdown();
             TestPlanView.RemoveRecoveryfile();
-            Console.BufferHeight = bufferHeight;
+            if (canGetHeight)
+                SetBufferHeight(bufferHeight);
 
             return 0;
         }

--- a/OpenTAP.TUI/OpenTAP.TUI.cs
+++ b/OpenTAP.TUI/OpenTAP.TUI.cs
@@ -205,13 +205,24 @@ namespace OpenTap.Tui
             {
                 new MenuItem("New", "", () =>
                 {
-                    TestPlanView.NewTestPlan();
-                    StepSettingsView.LoadProperties(null);
+                    if (TestPlanView.SaveOrDiscard())
+                    {
+                        TestPlanView.NewTestPlan();
+                        StepSettingsView.LoadProperties(null);
+                    }
                 }),
-                new MenuItem("Open", "", TestPlanView.LoadTestPlan),
+                new MenuItem("Open", "", () => 
+                {
+                    if (TestPlanView.SaveOrDiscard())
+                        TestPlanView.LoadTestPlan();
+                }),
                 new MenuItem("Save", "", () => { TestPlanView.SaveTestPlan(TestPlanView.Plan.Path); }),
                 new MenuItem("Save As", "", () => { TestPlanView.SaveTestPlan(null); }),
-                new MenuItem("Quit", "", () => Application.RequestStop())
+                new MenuItem("Quit", "", () => 
+                {
+                    if (TestPlanView.SaveOrDiscard()) 
+                        Application.RequestStop();
+                }),
             });
             var editMenu = new MenuBarItem("Edit", new MenuItem[]
             {

--- a/OpenTAP.TUI/OpenTAP.TUI.cs
+++ b/OpenTAP.TUI/OpenTAP.TUI.cs
@@ -224,14 +224,8 @@ namespace OpenTap.Tui
                         Application.RequestStop();
                 }),
             });
-            var editMenu = new MenuBarItem("Edit", new MenuItem[]
-            {
-                new MenuItem("New", "", () =>
-                {
-                    TestPlanView.NewTestPlan();
-                    StepSettingsView.LoadProperties(null);
-                }),
-            });
+            // This menu is populated later
+            var editMenu = new MenuBarItem("Edit", Array.Empty<MenuItem>());
             var toolsmenu = new MenuBarItem("Tools", new MenuItem[]
             {
                 new MenuItem("Results Viewer (Experimental)", "", () =>

--- a/OpenTAP.TUI/Views/TestPlanView.cs
+++ b/OpenTAP.TUI/Views/TestPlanView.cs
@@ -380,12 +380,30 @@ namespace OpenTap.Tui.Views
             treeView.SetTreeViewSource(Plan.Steps);
             UpdateTitle();
         }
+        public bool SaveOrDiscard()
+        {
+            if (MainWindow.ContainsUnsavedChanges)
+            {
+                switch (MessageBox.Query(50, 7, "Unsaved changes!", "Do you want to save before exiting?", "Save", "Don't save", "Cancel"))
+                {
+                    case 0:
+                        // Save.
+                        SaveTestPlan(Plan.Path);
+                        return true;
+                    case 1:
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+            return true;
+        }
         
         public void NewTestPlan()
         {
             recoveryFile.Plan = new TestPlan();
             treeView.SetTreeViewSource(Plan.Steps);
-            MainWindow.ContainsUnsavedChanges = true;
+            MainWindow.ContainsUnsavedChanges = false;
         }
         public void SaveTestPlan(string path)
         {


### PR DESCRIPTION
This fixes two bugs:

* Catch exception related to setting buffer height at exit
* Add dialog when quitting/newing/loading test plan if the current test plan has unsaved changes