### PR TITLE
vscode files broken on linux

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,9 +10,9 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/OpenTAP.TUI/bin/Debug/tap.exe",
+            "program": "${workspaceFolder}/OpenTap.TUI/bin/Debug/tap.exe",
             "args": ["tui", "../../Untitled.TapPlan"],
-            "cwd": "${workspaceFolder}/OpenTAP.TUI/bin/Debug",
+            "cwd": "${workspaceFolder}/OpenTap.TUI/bin/Debug",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
             "console": "externalTerminal",
             "stopAtEntry": false
@@ -24,8 +24,8 @@
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
             "program": "dotnet",
-            "args": ["${workspaceFolder}/OpenTAP.TUI/bin/Debug/tap.dll", "tui"],
-            "cwd": "${workspaceFolder}/OpenTAP.TUI/bin/Debug",
+            "args": ["${workspaceFolder}/OpenTap.TUI/bin/Debug/tap.dll", "tui"],
+            "cwd": "${workspaceFolder}/OpenTap.TUI/bin/Debug",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
             "console": "externalTerminal",
             "stopAtEntry": false

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,7 @@
             "type": "process",
             "args": [
                 "build",
-                "${workspaceFolder}/OpenTAP.TUI/OpenTAP.TUI.csproj"
+                "${workspaceFolder}/OpenTAP.TUI/OpenTap.Tui.csproj"
             ],
             "problemMatcher": "$tsc"
         },
@@ -17,7 +17,7 @@
             "type": "process",
             "args": [
                 "publish",
-                "${workspaceFolder}/OpenTAP.TUI/OpenTAP.TUI.csproj"
+                "${workspaceFolder}/OpenTAP.TUI/OpenTap.Tui.csproj"
             ],
             "problemMatcher": "$tsc"
         },
@@ -28,7 +28,7 @@
             "args": [
                 "watch",
                 "run",
-                "${workspaceFolder}/OpenTAP.TUI/OpenTAP.TUI.csproj"
+                "${workspaceFolder}/OpenTAP.TUI/OpenTap.Tui.csproj"
             ],
             "problemMatcher": "$tsc"
         }


### PR DESCRIPTION
On Linux, the file system is typically case sensitive. The current vscode launch files are using inconsistent casing.