### PR TITLE
fix package manager hang condition

### DIFF
--- a/OpenTAP.TUI/Views/PackageListView.cs
+++ b/OpenTAP.TUI/Views/PackageListView.cs
@@ -46,7 +46,7 @@ namespace OpenTap.Tui.Views
 
         public PackageListView()
         {
-            installation = new Installation(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
+            installation = Installation.Current;
             installedOpentap = installation.GetOpenTapPackage();
             installedPackages = installation.GetPackages();
             

--- a/OpenTAP.TUI/Windows/PackageVersionSelectorWindow.cs
+++ b/OpenTAP.TUI/Windows/PackageVersionSelectorWindow.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -103,10 +104,22 @@ namespace OpenTap.Tui.Windows
             bool running = true;
             Task.Run(() =>
             {
-                versions = GetVersions();
-                UpdateVersions();
-                running = false;
-            });
+                try
+                {
+                    versions = GetVersions();
+                    UpdateVersions();
+                }
+                catch (Exception ex)
+                {
+                    var log = Log.CreateSource("Package Manager");
+                    log.Error($"Error getting package versions: '{ex.Message}'"); 
+                    log.Debug(ex);
+                }
+                finally
+                {
+                    running = false;
+                }
+            }).GetAwaiter().GetResult();
             Task.Run(() =>
             {
                 while (running)
@@ -131,7 +144,7 @@ namespace OpenTap.Tui.Windows
                         Application.RequestStop();
                     }
                 });
-            });
+            }).GetAwaiter().GetResult();
         }
 
         void InstallButtonClicked(bool force)


### PR DESCRIPTION
Two issues caused the package manager to hang:
1. Incorrect installation detection caused an unhandled exception
2. Unawaited tasks caused the unhandled exception to get swallowed