### PR TITLE
Hide disabled menu items

### DIFF
--- a/OpenTAP.TUI/Views/PropertiesView.cs
+++ b/OpenTAP.TUI/Views/PropertiesView.cs
@@ -47,6 +47,8 @@ namespace OpenTap.Tui.Views
                 var member = _member;
                 if (member.Get<IAccessAnnotation>()?.IsVisible == false)
                     continue;
+                if (member.Get<IEnabledAnnotation>()?.IsEnabled == false)
+                    continue;
                 
                 var item = new MenuItem(KeyMapHelper.GetShortcutKey((KeyTypes)((int)KeyTypes.HelperButton1 + keyNum++)));
                 item.Title = member.Get<DisplayAttribute>().Name;


### PR DESCRIPTION
Currently, disabled menu items take up horizontal space, and reserve custom keybind slot, which is a limited resource. By skipping disabled items, we reduce the likelihood of needing to go to the Edit menu to access edit options.